### PR TITLE
#find_by_title only return movies

### DIFF
--- a/lib/imdb_party/imdb.rb
+++ b/lib/imdb_party/imdb.rb
@@ -31,7 +31,7 @@ module ImdbParty
     end
 
     def find_by_title(title)
-      default_find_by_title_params = {"json" => "1", "nr" => 1, "tt" => "on", "q" => title}
+      default_find_by_title_params = {"json" => "1", "nr" => 1, "tt" => "on", "ttype" => "ft", "q" => title}
 
       movie_results = []
 


### PR DESCRIPTION
What do think about filtering the search to show only movies?
Look the difference when searching for "The Proposal": http://pastie.org/pastes/8968996/text
(those are the results with exact matching on title)

Is many people out there using this gem for TV series? If you wish, I could create another method #find_movies_by_title, instead of overwriting your #find_by_title method.

(anyway, thanks for this great gem :+1:)
